### PR TITLE
Feat/implementar endpoint para login com google

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,5 @@ PG_HOST=localhost
 JWT_SECRET=secretOrKey
 
 DATABASE_URL="postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}"
+
+SERVER_PORT=8000

--- a/.env
+++ b/.env
@@ -8,3 +8,5 @@ JWT_SECRET=secretOrKey
 DATABASE_URL="postgresql://${PG_USER}:${PG_PASSWORD}@${PG_HOST}:${PG_PORT}/${PG_DB}"
 
 SERVER_PORT=8000
+
+GOOGLE_CLIENT_ID=232442004958-prlsjpocksmqecooma4cvpm33c0co829.apps.googleusercontent.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "bcryptjs": "^2.4.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
+        "google-auth-library": "^9.15.1",
         "lodash": "^4.17.21",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
@@ -4475,7 +4476,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4511,6 +4511,15 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/bin-version": {
       "version": "6.0.0",
@@ -6198,6 +6207,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -6888,6 +6903,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7051,6 +7118,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7102,6 +7216,40 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/gtoken/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7474,7 +7622,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8325,6 +8472,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -11676,6 +11832,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "google-auth-library": "^9.15.1",
     "lodash": "^4.17.21",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,8 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
 
-  await app.listen(3000);
-  console.log(`API docs disponíveis em: http://localhost:3000/api-docs`);
+  const port = process.env.SERVER_PORT || 3000;
+  await app.listen(port);
+  console.log(`API docs disponíveis em: http://localhost:${port}/api-docs`);
 }
 bootstrap();

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -3,34 +3,48 @@ import { AuthService } from "./auth.service";
 import { LoginDto } from './dtos/login.dto';
 import { ApiBody, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { GoogleDto } from './dtos/google.dto';
 
-@Controller('user/auth')
+@Controller("user/auth")
 export class AuthController {
-    constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) {}
 
-    @Post('login')
-    @ApiOperation({ 
-        summary: 'Login',
-        description: 'Authenticates the user and returns an access token'
-    })
-    @ApiBody({ type: LoginDto })
-    @ApiResponse({ status: 200, description: 'Login successfully' })
-    @ApiResponse({ status: 400, description: 'Bad Request' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    async login(@Body() data: LoginDto) {
-        return this.authService.login(data);
-    }
+  @Post("login")
+  @ApiOperation({
+    summary: "Login",
+    description: "Authenticates the user and returns an access token",
+  })
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({ status: 200, description: "Login successfully" })
+  @ApiResponse({ status: 400, description: "Bad Request" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async login(@Body() data: LoginDto) {
+    return this.authService.login(data);
+  }
 
-    @Get('me')
-    @UseGuards(JwtAuthGuard)
-    @ApiOperation({ 
-        summary: 'Get the authenticated user',
-        description: 'Returns the details of the authenticated user'
-    })
-    @ApiResponse({ status: 200, description: 'Return the authenticated user' })
-    @ApiResponse({ status: 401, description: 'Unauthorized' })
-    @ApiBearerAuth()
-    async me(@Request() req) {
-        return req.user;
-    }
+  @Post("google")
+  @ApiOperation({
+    summary: "Verify login with Google",
+    description: "Authenticates the user with Google and returns an access token",
+  })
+  @ApiBody({ type: GoogleDto })
+  @ApiResponse({ status: 200, description: "Login successful" })
+  @ApiResponse({ status: 400, description: "Bad Request" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  async verifyAndLoginWithGoogle(@Body() data: GoogleDto) {
+    return this.authService.loginWithGoogle(data);
+  }
+
+  @Get("me")
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "Get the authenticated user",
+    description: "Returns the details of the authenticated user",
+  })
+  @ApiResponse({ status: 200, description: "Return the authenticated user" })
+  @ApiResponse({ status: 401, description: "Unauthorized" })
+  @ApiBearerAuth()
+  async me(@Request() req) {
+    return req.user;
+  }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,32 +1,82 @@
 import { Injectable, UnauthorizedException } from "@nestjs/common";
-import * as bcrypt from 'bcrypt';
+import * as bcrypt from "bcrypt";
 import { omit } from "lodash";
-import  { JwtService } from '@nestjs/jwt';
-import { UserService } from '../user/user.service';
+import { JwtService } from "@nestjs/jwt";
+import { UserService } from "../user/user.service";
+import { OAuth2Client } from "google-auth-library";
+
+const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 @Injectable()
 export class AuthService {
-    constructor(
-        private readonly userService: UserService,
-        private readonly jwtService: JwtService
-    ) {}
+  constructor(
+    private readonly userService: UserService,
+    private readonly jwtService: JwtService
+  ) {}
 
-    async validateUser (email: string, password: string) {
-        const user = await this.userService.findUserWithPassword(email);
+  async validateUser(email: string, password: string) {
+    const user = await this.userService.findUserWithPassword(email);
 
-        if (user && (await bcrypt.compare(password, user.password)) && user.is_active == true) {
-            return omit(user, ['password']);
-        } else {
-            throw new UnauthorizedException('Invalid credentials');
-        }
+    if (
+      user &&
+      (await bcrypt.compare(password, user.password)) &&
+      user.is_active == true
+    ) {
+      return omit(user, ["password"]);
+    } else {
+      throw new UnauthorizedException("Invalid credentials");
+    }
+  }
+
+  async login(user: any) {
+    const validatedUser = await this.validateUser(user.email, user.password);
+    const payload = {
+      email: validatedUser.email,
+      sub: validatedUser.id,
+      type: validatedUser.type,
+    };
+    return {
+      access_token: this.jwtService.sign(payload),
+      user: validatedUser,
+    };
+  }
+
+  async loginWithGoogle(data: any) {
+    const { email, id_token } = data;
+    const googlePayload = await this.verifyGoogleToken(id_token);
+    if (googlePayload == undefined) {
+      throw new UnauthorizedException("Invalid ID token");
+    }
+    
+    
+    const user = await this.userService.findUserWithPassword(email);
+    if (!user || user.is_active == false) {
+      throw new UnauthorizedException(
+        "Invalid credentials or unauthorized user"
+      );
     }
 
-    async login(user: any) { 
-        const validatedUser = await this.validateUser(user.email, user.password);
-        const payload = { email: validatedUser.email, sub: validatedUser.id, type: validatedUser.type };
-        return {
-            access_token: this.jwtService.sign(payload),
-            user: validatedUser
-        };
+    const payload = {
+      email: user.email,
+      sub: user.id,
+      type: user.type,
+    };
+
+    return {
+      access_token: this.jwtService.sign(payload),
+      user: omit(user, ["password"]),
+    };
+  }
+
+  async verifyGoogleToken(idToken) {
+    try {
+      const ticket = await client.verifyIdToken({
+        idToken,
+        audience: process.env.GOOGLE_CLIENT_ID,
+      });
+      return ticket.getPayload();
+    } catch (error) {
+      return undefined;
     }
+  }
 }

--- a/src/modules/auth/dtos/google.dto.ts
+++ b/src/modules/auth/dtos/google.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength, IsNotEmpty, Matches } from 'class-validator';
+export class GoogleDto {
+  @ApiProperty({
+    example: "user@educ.al.gov.br",
+    description:
+      'The email of the user. Must belong to the domain "educ.al.gov.br".',
+  })
+  @IsNotEmpty({ message: "Email is required" })
+  @IsEmail({}, { message: "Invalid email" })
+  email: string;
+
+  @ApiProperty({
+    example: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+    description:
+      "The idToken is returned by Google OAuth API, and is a JWT containing information on the authenticated user.",
+  })
+  @IsNotEmpty({ message: "Token is required" })
+  @IsString({ message: "Token must be a string" })
+  id_token: string;
+}

--- a/src/modules/auth/dtos/google.dto.ts
+++ b/src/modules/auth/dtos/google.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength, IsNotEmpty, Matches } from 'class-validator';
+import { IsEmail, IsString, IsNotEmpty} from 'class-validator';
 export class GoogleDto {
   @ApiProperty({
     example: "user@educ.al.gov.br",


### PR DESCRIPTION
### O que foi feito: 

- Adicionado `SERVER_PORT` no `.env `para maior flexibilidade.
- Adicionado `GOOGLE_CLIENT_ID` no `.env` para suportar a verificação do ID token fornecido pelo Google.
- Criado endpoint `POST /user/auth/google` no controller de autenticação, com dto, para receber o email e id_token do front quando um usuário logar com Google. 
- Criado serviços para verificar a autenticidade e validade do token usando o pacote `google-auth-library`, e para autenticar o usuário que fez login com google. O método `loginWithGoogle(data)` valida o id_token, e verifica se há usuário cadastrado com o email fornecido. Se houver, ele retorna o usuário junto com um accessToken. 